### PR TITLE
Add secondary country to signals data

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,6 +27,7 @@ services:
       - ./sql/create_tables.sql:/docker-entrypoint-initdb.d/1-create_tables.sql
       - ./sql/import_data.sql:/docker-entrypoint-initdb.d/2-import_data.sql
       - ./sql/init_test_data.sql:/docker-entrypoint-initdb.d/3-init_test_data.sql
+      - ./sql/add_secondary_location.sql:/app/sql/add_secondary_location.sql
       - ./data:/docker-entrypoint-initdb.d/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]

--- a/sql/add_secondary_location.sql
+++ b/sql/add_secondary_location.sql
@@ -1,0 +1,24 @@
+/*
+Migration script to add secondary_location column to signals table.
+Run this script to update the database schema.
+*/
+
+-- Add secondary_location column to signals table
+ALTER TABLE signals ADD COLUMN IF NOT EXISTS secondary_location TEXT[];
+
+-- Update the index to include the new column
+DROP INDEX IF EXISTS signals_idx;
+CREATE INDEX ON signals (
+    status,
+    created_by,
+    created_for,
+    created_unit,
+    steep_primary,
+    steep_secondary,
+    signature_primary,
+    signature_secondary,
+    sdgs,
+    location,
+    secondary_location,
+    score
+); 

--- a/src/database/signals.py
+++ b/src/database/signals.py
@@ -137,6 +137,7 @@ async def create_signal(cursor: AsyncCursor, signal: Signal) -> int:
             relevance,
             keywords,
             location,
+            secondary_location,
             score
         )
         VALUES (
@@ -156,6 +157,7 @@ async def create_signal(cursor: AsyncCursor, signal: Signal) -> int:
             %(relevance)s,
             %(keywords)s,
             %(location)s,
+            %(secondary_location)s,
             %(score)s
         )
         RETURNING
@@ -263,6 +265,7 @@ async def update_signal(cursor: AsyncCursor, signal: Signal) -> int | None:
              relevance = COALESCE(%(relevance)s, relevance),
              keywords = COALESCE(%(keywords)s, keywords),
              location = COALESCE(%(location)s, location),
+             secondary_location = COALESCE(%(secondary_location)s, secondary_location),
              score = COALESCE(%(score)s, score)
         WHERE
             id = %(id)s

--- a/src/entities/signal.py
+++ b/src/entities/signal.py
@@ -24,6 +24,10 @@ class Signal(BaseEntity):
         default=None,
         description="Region and/or country for which this signal has greatest relevance.",
     )
+    secondary_location: list[str] | None = Field(
+        default=None,
+        description="Additional regions and/or countries for which this signal has relevance.",
+    )
     score: utils.Score | None = Field(default=None)
     connected_trends: list[int] | None = Field(
         default=None,
@@ -42,6 +46,7 @@ class Signal(BaseEntity):
                 "relevance": "Of the approximately US$13 trillion that governments spend on public spending, up to 25 percent is lost to corruption.",
                 "keywords": ["economy", "governance"],
                 "location": "Global",
+                "secondary_location": ["Africa", "Asia"],
                 "favorite": False,
             }
         }

--- a/src/entities/signal.py
+++ b/src/entities/signal.py
@@ -40,14 +40,17 @@ class Signal(BaseEntity):
 
     model_config = ConfigDict(
         json_schema_extra={
-            "example": BaseEntity.model_config["json_schema_extra"]["example"]
-            | {
+            "example": {
+                "id": 1,
+                "created_unit": "HQ",
                 "url": "https://undp.medium.com/the-cost-of-corruption-a827306696fb",
                 "relevance": "Of the approximately US$13 trillion that governments spend on public spending, up to 25 percent is lost to corruption.",
                 "keywords": ["economy", "governance"],
                 "location": "Global",
                 "secondary_location": ["Africa", "Asia"],
-                "favorite": False,
+                "score": None,
+                "connected_trends": [101, 102],
+                "favorite": False
             }
         }
     )


### PR DESCRIPTION
## Summary

This request adds support for a new attribute `secondary_location` to the `Signal` entity. This allows signals to be associated with additional regions and/or countries, improving the flexibility and expressiveness of the data model. The change includes updates to the database schema, backend entity model, and CRUD operations. The migration is handled via a new SQL script and is integrated into the Docker setup.

## New Features

- Added a new `secondary_location` attribute (as a list of strings) to the `Signal` entity in the backend model (`src/entities/signal.py`).
- Updated CRUD operations in `src/database/signals.py` to support the new attribute.
- Added a database migration script (`sql/add_secondary_location.sql`) to add the `secondary_location` column to the `signals` table and update relevant indexes.
- Integrated the migration script into the Docker Compose workflow (`docker-compose.yaml`).

## Bug Fixes

- No bug fixes.

## Checklist

- [x] I have read the [contribution guidelines](../README.md#contribute).
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added required dependencies to `requirements.txt`
- [x] I have updated the documentation (if applicable).